### PR TITLE
NLP tools are more easily accessable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,9 @@ pip install bgnlp
 ### Part-of-speech (PoS) tagging
 
 ```python
-from bgnlp import PosTagger, PosTaggerConfig
+from bgnlp import pos
 
 
-config = PosTaggerConfig()
-pos = PosTagger(config=config)
 print(pos("Това е библиотека за обработка на естествен език."))
 ```
 
@@ -72,12 +70,11 @@ print(pos("Това е библиотека за обработка на ест�
 ### Lemmatization
 
 ```python
-from bgnlp import LemmaTaggerConfig, LemmaTagger
+from bgnlp import lemmatize
 
 
-lemma = LemmaTagger(config=LemmaTaggerConfig())
 text = "Добре дошли!"
-print(lemma(text))
+print(lemmatize(text))
 ```
 
 ```bash
@@ -86,7 +83,7 @@ print(lemma(text))
 
 ```python
 # Generating a string of lemmas.
-print(lemma(text, as_string=True))
+print(lemmatize(text, as_string=True))
 ```
 
 ```bash
@@ -101,10 +98,9 @@ Currently, the available NER tags are:
 - `LOC` - Location
 
 ```python
-from bgnlp import NerTagger, NerTaggerConfig
+from bgnlp import ner
 
 
-ner = NerTagger(config=NerTaggerConfig())
 text = "Барух Спиноза е роден в Амстердам"
 
 print(f"Input: {text}")

--- a/bgnlp/__init__.py
+++ b/bgnlp/__init__.py
@@ -10,4 +10,9 @@ from bgnlp.tools.configs import (
 )
 
 
-__version__ = "0.1.4"
+pos = PosTagger(config=PosTaggerConfig())
+lemmatize = LemmaTagger(config=LemmaTaggerConfig())
+ner = NerTagger(conifg=NerTaggerConfig())
+
+
+__version__ = "0.2.0"

--- a/bgnlp/__init__.py
+++ b/bgnlp/__init__.py
@@ -12,7 +12,7 @@ from bgnlp.tools.configs import (
 
 pos = PosTagger(config=PosTaggerConfig())
 lemmatize = LemmaTagger(config=LemmaTaggerConfig())
-ner = NerTagger(conifg=NerTaggerConfig())
+ner = NerTagger(config=NerTaggerConfig())
 
 
 __version__ = "0.2.0"

--- a/examples/lemma_usage.py
+++ b/examples/lemma_usage.py
@@ -1,7 +1,13 @@
+from bgnlp import lemmatize
 from bgnlp import LemmaTaggerConfig, LemmaTagger
 
 
-lemma = LemmaTagger(config=LemmaTaggerConfig())
 text = "Добре дошли!"
 print("Input:", text)
+
+# You can either do this:
+print("Output:", lemmatize(text))
+
+# Or this:
+lemma = LemmaTagger(config=LemmaTaggerConfig())
 print("Output:", lemma("Добре дошли"))

--- a/examples/ner_usage.py
+++ b/examples/ner_usage.py
@@ -1,8 +1,13 @@
+from bgnlp import ner
 from bgnlp import NerTagger, NerTaggerConfig
 
 
-ner = NerTagger(config=NerTaggerConfig())
 text = "Барух Спиноза е роден в Амстердам"
-
 print(f"Input: {text}")
+
+# You can either do this:
+print("Result", ner(text))
+
+# Or this:
+ner = NerTagger(config=NerTaggerConfig())
 print("Result:", ner(text))

--- a/examples/pos_usage.py
+++ b/examples/pos_usage.py
@@ -1,9 +1,14 @@
+from bgnlp import pos
 from bgnlp import PosTagger, PosTaggerConfig
 
 
+text = "Това е библиотека за обработка на естествен език."
+print(f"Input: {text}")
+
+# You can either do this:
+print("Result:", pos(text))
+
+# Or this:
 config = PosTaggerConfig()
 pos = PosTagger(config=config)
-text = "Това е библиотека за обработка на естествен език."
-
-print(f"Input: {text}")
 print("Result:", pos(text))

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ REQUIREMENTS_PATH = os.path.join(ROOT, "requirements.txt")
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text(encoding="utf-8")
 
-VERSION = '0.1.4'
+VERSION = '0.2.0'
 DESCRIPTION = 'Package for Bulgarian Natural Language Processing (NLP)'
 
 


### PR DESCRIPTION
For example, instead of
```python
from bgnlp import NerTagger, NerTaggerConfig


ner = NerTagger(config=NerTaggerConfig())
ner(...)
```

you can directly do this
```python
from bgnlp import ner


ner(...)
```