### PR TITLE
Using strict dependency versioning

### DIFF
--- a/bgnlp/__init__.py
+++ b/bgnlp/__init__.py
@@ -21,4 +21,4 @@ extract_keywords = KeywordsTagger(config=KeywordsTaggerConfig())
 commatize = PunctuationTagger(config=PunctuationTaggerConfig())
 
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-torch
-numpy
-pandas
-torchmetrics
-torchtext
-transformers
-gdown
+torch==1.11.0
+numpy==1.26.2
+pandas==1.4.3
+torchmetrics==0.11.0
+torchtext==0.12.0
+transformers==4.26.0
+gdown==4.6.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ REQUIREMENTS_PATH = os.path.join(ROOT, "requirements.txt")
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text(encoding="utf-8")
 
-VERSION = '0.4.0'
+VERSION = '0.4.1'
 DESCRIPTION = 'Package for Bulgarian Natural Language Processing (NLP)'
 
 


### PR DESCRIPTION
The `requirements.txt` file now has strict versions. The NER model had problems with the newer transformer version.
The versions should be updated in the newer versions.